### PR TITLE
Few small changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "axios": "^0.19.2",
     "colors": "^1.4.0",
     "command-exists": "^1.2.8",
-    "iptv-playlist-parser": "^0.4.0",
+    "iptv-playlist-parser": "^0.4.2",
     "valid-url": "^1.0.9"
   },
   "devDependencies": {

--- a/src/helper.js
+++ b/src/helper.js
@@ -3,7 +3,6 @@ const util = require('util')
 const { parse } = require('iptv-playlist-parser')
 const { isWebUri } = require('valid-url')
 const { existsSync, readFile } = require('fs')
-const { isAbsolute } = require('path')
 
 const execAsync = util.promisify(require('child_process').exec)
 const readFileAsync = util.promisify(readFile)

--- a/src/helper.js
+++ b/src/helper.js
@@ -67,7 +67,7 @@ async function parsePlaylist(input) {
   } else if (typeof input === `string`) {
     if (isWebUri(input)) {
       data = await axios(input)
-    } else if (isAbsolute(input) && existsSync(input)) {
+    } else if (existsSync(input)) {
       data = await readFileAsync(input, { encoding: `utf8` })
     }
   }


### PR DESCRIPTION
- Removes the check whether the path is absolute
Otherwise, it is impossible to use the relative path to the file.

- Updated `iptv-playlist-parser` package
The new version fixes the bug of parsing the channels in the description of which the comma is used. 